### PR TITLE
white list update for offline or sever side

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,3 +1,6 @@
 WikiSysop
 Hexmode
 Spammer
+127.0.01
+localhost
+192.168.0.1


### PR DESCRIPTION
if possible mediawiki extension block and nuke add hostnames and ip addresses to block and nuke whitelist.txt
127.0.0.1
localhost
192.168.0.1

