### PR TITLE
Add a way to not use merge even if available

### DIFF
--- a/BanPests.php
+++ b/BanPests.php
@@ -154,10 +154,12 @@ class BanPests {
 	 * @return array|bool|null
 	 */
 	public static function banUser( $user, $banningUser, $spammer ) {
+		global $wgBaNnomerge;
+
 		$ret = null;
 		if ( !is_object( $user ) ) {
 			/* Skip this one */
-		} elseif ( $user->getID() != 0 && class_exists( "MergeUser" ) ) {
+		} elseif ( !$wgBaNnomerge && $user->getID() != 0 && class_exists( "MergeUser" ) ) {
 			$um = new MergeUser( $spammer, $user );
 			$ret = $um->merge( $banningUser, __METHOD__ );
 		} else {


### PR DESCRIPTION
Hello,

We have the UserMerge extension but we do not want BlockAndNuke to use it.
This patch adds a new `$wgBaNnomerge` that makes that possible.